### PR TITLE
Add support for step PICS in python tests

### DIFF
--- a/app/chip_tool/test_suite.py
+++ b/app/chip_tool/test_suite.py
@@ -60,7 +60,7 @@ class ChipToolSuite(TestSuite, UserPromptSupport):
 
         if len(self.pics.clusters) > 0:
             logger.info("Create PICS file for DUT")
-            self.chip_tool.set_pics(pics=self.pics)
+            self.chip_tool.set_pics(pics=self.pics, in_container=False)
         else:
             # Disable sending "-PICS" option when running chip-tool
             self.chip_tool.reset_pics_state()

--- a/app/tests/chip_tool/test_chip_tool.py
+++ b/app/tests/chip_tool/test_chip_tool.py
@@ -454,7 +454,7 @@ async def test_set_pics() -> None:
     ) as mock_run:
         await chip_tool.start_server(test_type)
 
-        chip_tool.set_pics(pics)
+        chip_tool.set_pics(pics, in_container=False)
 
     mock_run.assert_called_once_with(expected_command, shell=True)
     assert chip_tool._ChipTool__pics_file_created is True
@@ -473,7 +473,7 @@ def test_set_pics_with_error() -> None:
         target="app.chip_tool.chip_tool.subprocess.run",
         return_value=CompletedProcess("", 1),
     ), pytest.raises(PICSError):
-        chip_tool.set_pics(pics)
+        chip_tool.set_pics(pics, in_container=False)
         assert chip_tool._ChipTool__pics_file_created is False
 
     # clean up:

--- a/app/tests/chip_tool/test_chip_tool.py
+++ b/app/tests/chip_tool/test_chip_tool.py
@@ -111,7 +111,6 @@ async def test_start_container_using_paa_certs() -> None:
 @pytest.mark.asyncio
 async def test_not_start_container_when_running() -> None:
     chip_tool = ChipTool()
-    test_type = ChipToolTestType.CHIP_TOOL
 
     with mock.patch.object(
         target=chip_tool, attribute="is_running", return_value=True
@@ -120,7 +119,7 @@ async def test_not_start_container_when_running() -> None:
     ) as mock_create_container, mock.patch.object(
         target=chip_tool, attribute="start_chip_server"
     ) as mock_start_chip_server:
-        await chip_tool.start_server(test_type)
+        await chip_tool.start_container()
 
     mock_create_container.assert_not_called()
     mock_start_chip_server.assert_not_called()
@@ -432,7 +431,7 @@ async def test_set_pics() -> None:
         "PICS_USER_PROMPT=1"
     )
     expected_command = (
-        f"{SHELL_PATH} {SHELL_OPTION} \"echo '{expected_pics_data}\n' "
+        f"{SHELL_PATH} {SHELL_OPTION} \"echo '{expected_pics_data}' "
         f'> {PICS_FILE_PATH}"'
     )
 

--- a/test_collections/sdk_tests/support/python_testing/models/rpc_client/test_harness_client.py
+++ b/test_collections/sdk_tests/support/python_testing/models/rpc_client/test_harness_client.py
@@ -23,39 +23,18 @@ from multiprocessing.managers import BaseManager
 
 import matter_testing_support
 
-try:
-    from matter_yamltests.hooks import TestRunnerHooks
-except:
 
-    class TestRunnerHooks:
-        pass
-
-
-MATTER_DEVELOPMENT_PAA_ROOT_CERTS = "/paa-root-certs"
-
-# Pre-computed param list for each Python Test as defined in Verification Steps.
-test_params = {
-    "TC_ACE_1_3": matter_testing_support.MatterTestConfig(
-        tests=["test_TC_ACE_1_3"],
-        commissioning_method="on-network",
-        discriminators=[3840],
-        setup_passcodes=[20202021],
-        dut_node_ids=[0x12344321],
-        paa_trust_store_path=MATTER_DEVELOPMENT_PAA_ROOT_CERTS,
-        storage_path="/root/admin_storage.json",
-    )
-}
+class TestRunnerHooks:
+    pass
 
 
 def main() -> None:
     sys.path.append("/root/python_testing")
 
-    if len(sys.argv) != 2:
-        raise Exception("Python test id should be provided as the only parameter.")
-
     test_name = sys.argv[1]
 
-    config = test_params.get(test_name)
+    config_options = sys.argv[2:]
+    config = matter_testing_support.parse_matter_test_args(config_options)
 
     if config is None:
         raise ValueError(f"Not a valid test id: {test_name}")


### PR DESCRIPTION
## What changed

- Added support for setting PICS for python tests.
- Moved SDK start and destroy logic from test case to test suite.
- Removed duplicate Python version log.
- Added arguments parsing for when running python tests.

## Testing

Modified `TC-ACE-1.3` to check for PICS in a step
<img width="2160" alt="Screenshot 2023-11-30 at 18 22 36" src="https://github.com/rquidute/certification-tool-backend/assets/116589288/2643f45a-3795-41bc-af02-121450d86c14">

Ran a `CHIP_TOOL` and a `CHIP_APP` test and verified that they still work and that the step PICS validation is also working as expected.