### PR TITLE
Run multiple python tests

### DIFF
--- a/app/test_engine/logger.py
+++ b/app/test_engine/logger.py
@@ -22,5 +22,9 @@ test_engine_logger = logger.bind(test_run_log=True)
 CHIPTOOL_LEVEL = "CHIPTOOL"
 test_engine_logger.level(CHIPTOOL_LEVEL, no=21, icon="🤖", color="<cyan>")
 
+# Add custom logger for python tests
+PYTHON_TEST_LEVEL = "PYTHON_TEST"
+test_engine_logger.level(PYTHON_TEST_LEVEL, no=22, icon="🐍", color="<cyan>")
+
 # Log format for logs that come from CHIP. Arguments: module (e.g. "DMG"), message
 CHIP_LOG_FORMAT = "CHIP:{} {}"

--- a/app/tests/python_tests/test_python_test_suite.py
+++ b/app/tests/python_tests/test_python_test_suite.py
@@ -29,6 +29,10 @@ from test_collections.sdk_tests.support.python_testing.models.test_suite import 
     PythonTestSuite,
     SuiteType,
 )
+from test_collections.sdk_tests.support.python_testing.models.utils import (
+    EXECUTABLE,
+    RUNNER_CLASS_PATH,
+)
 
 
 def test_python_suite_class_factory_name() -> None:
@@ -154,6 +158,37 @@ async def test_suite_setup_with_pics() -> None:
         mock_set_pics.assert_called_once()
         mock_reset_pics_state.assert_not_called()
         mock_commission_device.called_once()
+
+
+@pytest.mark.asyncio
+async def test_commission_device() -> None:
+    chip_tool: ChipTool = ChipTool()
+
+    command_args = ["arg1", "arg2", "arg3"]
+    expected_command = [f"{RUNNER_CLASS_PATH} commission"]
+    expected_command.extend(command_args)
+
+    suite = PythonTestSuite(TestSuiteExecution())
+
+    with mock.patch.object(target=chip_tool, attribute="start_container"), mock.patch(
+        target="test_collections.sdk_tests.support.python_testing.models.test_suite"
+        ".PythonTestSuite.config"
+    ), mock.patch.object(
+        target=chip_tool, attribute="send_command"
+    ) as mock_send_command, mock.patch(
+        target="test_collections.sdk_tests.support.python_testing.models.test_suite"
+        ".generate_command_arguments",
+        return_value=command_args,
+    ), mock.patch(
+        target="test_collections.sdk_tests.support.python_testing.models.test_suite"
+        ".handle_logs"
+    ) as mock_handle_logs:
+        suite.commission_device()
+
+    mock_send_command.assert_called_once_with(
+        expected_command, prefix=EXECUTABLE, is_stream=True, is_socket=False
+    )
+    mock_handle_logs.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/app/tests/python_tests/test_python_test_suite.py
+++ b/app/tests/python_tests/test_python_test_suite.py
@@ -81,8 +81,11 @@ async def test_suite_setup_log_python_version() -> None:
             target="test_collections.sdk_tests.support.python_testing.models.test_suite"
             ".PythonTestSuite.pics",
             new_callable=PICS,
+        ), mock.patch.object(
+            target=suite_instance, attribute="commission_device"
         ):
             await suite_instance.setup()
+
             logger_info.assert_called()
             logger_info.assert_any_call(f"Python Test Version: {python_test_version}")
 
@@ -110,11 +113,14 @@ async def test_suite_setup_without_pics() -> None:
             target=chip_tool, attribute="set_pics"
         ) as mock_set_pics, mock.patch.object(
             target=chip_tool, attribute="reset_pics_state"
-        ) as mock_reset_pics_state:
+        ) as mock_reset_pics_state, mock.patch.object(
+            target=suite_instance, attribute="commission_device"
+        ) as mock_commission_device:
             await suite_instance.setup()
 
         mock_set_pics.assert_not_called()
         mock_reset_pics_state.assert_called_once()
+        mock_commission_device.called_once()
 
 
 @pytest.mark.asyncio
@@ -140,11 +146,14 @@ async def test_suite_setup_with_pics() -> None:
             target=chip_tool, attribute="set_pics"
         ) as mock_set_pics, mock.patch.object(
             target=chip_tool, attribute="reset_pics_state"
-        ) as mock_reset_pics_state:
+        ) as mock_reset_pics_state, mock.patch.object(
+            target=suite_instance, attribute="commission_device"
+        ) as mock_commission_device:
             await suite_instance.setup()
 
         mock_set_pics.assert_called_once()
         mock_reset_pics_state.assert_not_called()
+        mock_commission_device.called_once()
 
 
 @pytest.mark.asyncio

--- a/test_collections/sdk_tests/support/python_testing/models/rpc_client/test_harness_client.py
+++ b/test_collections/sdk_tests/support/python_testing/models/rpc_client/test_harness_client.py
@@ -21,7 +21,12 @@ import importlib
 import sys
 from multiprocessing.managers import BaseManager
 
-import matter_testing_support
+from matter_testing_support import (
+    CommissionDeviceTest,
+    MatterTestConfig,
+    parse_matter_test_args,
+    run_tests,
+)
 
 
 class TestRunnerHooks:
@@ -31,14 +36,16 @@ class TestRunnerHooks:
 def main() -> None:
     sys.path.append("/root/python_testing")
 
-    test_name = sys.argv[1]
+    test_args = sys.argv[2:]
+    config = parse_matter_test_args(test_args)
 
-    config_options = sys.argv[2:]
-    config = matter_testing_support.parse_matter_test_args(config_options)
+    if sys.argv[1] == "commission":
+        commission(config)
+    else:
+        run_test(test_name=sys.argv[1], config=config)
 
-    if config is None:
-        raise ValueError(f"Not a valid test id: {test_name}")
 
+def run_test(test_name: str, config: MatterTestConfig) -> None:
     module = importlib.import_module(test_name)
     TestClassReference = getattr(module, test_name)
 
@@ -47,7 +54,12 @@ def main() -> None:
     manager.connect()
     test_runner_hooks = manager.TestRunnerHooks()  # shared object proxy # type: ignore
 
-    matter_testing_support.run_tests(TestClassReference, config, test_runner_hooks)
+    run_tests(TestClassReference, config, test_runner_hooks)
+
+
+def commission(config: MatterTestConfig) -> None:
+    config.commission_only = True
+    run_tests(CommissionDeviceTest, config, None)
 
 
 if __name__ == "__main__":

--- a/test_collections/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/sdk_tests/support/python_testing/models/test_suite.py
@@ -14,11 +14,18 @@
 # limitations under the License.
 #
 from enum import Enum
-from typing import Type, TypeVar
+from typing import Generator, Type, TypeVar, cast
 
 from app.chip_tool import ChipTool
 from app.test_engine.logger import test_engine_logger as logger
 from app.test_engine.models import TestSuite
+
+from .utils import (
+    EXECUTABLE,
+    RUNNER_CLASS_PATH,
+    generate_command_arguments,
+    handle_logs,
+)
 
 
 class SuiteType(Enum):
@@ -74,8 +81,25 @@ class PythonTestSuite(TestSuite):
         else:
             self.chip_tool.reset_pics_state()
 
+        logger.info("Commission DUT")
+        self.commission_device()
+
     async def cleanup(self) -> None:
         logger.info("Suite Cleanup")
 
         logger.info("Stopping SDK container")
         await self.chip_tool.destroy_device()
+
+    def commission_device(self) -> None:
+        command = [f"{RUNNER_CLASS_PATH} commission"]
+        command_arguments = generate_command_arguments(config=self.config)
+        command.extend(command_arguments)
+
+        exec_result = self.chip_tool.send_command(
+            command,
+            prefix=EXECUTABLE,
+            is_stream=True,
+            is_socket=False,
+        )
+
+        handle_logs(cast(Generator, exec_result.output), logger)

--- a/test_collections/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/sdk_tests/support/python_testing/models/utils.py
@@ -1,0 +1,94 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from typing import Generator
+
+import loguru
+
+from app.schemas.test_environment_config import TestEnvironmentConfig
+from app.test_engine.logger import PYTHON_TEST_LEVEL
+from app.test_engine.logger import test_engine_logger as logger
+
+# Command line params
+RUNNER_CLASS_PATH = "/root/python_testing/test_harness_client.py"
+EXECUTABLE = "python3"
+
+
+def generate_command_arguments(
+    config: TestEnvironmentConfig, omit_commissioning_method: bool = False
+) -> list:
+    # All valid arguments for python test
+    valid_args = [
+        "ble_interface_id",
+        "commissioning_method",
+        "controller_node_id",
+        "discriminator",
+        "endpoint",
+        "logs_path",
+        "PICS",
+        "paa_trust_store_path",
+        "timeout",
+        "trace_to",
+        "int_arg",
+        "float_arg",
+        "string_arg",
+        "json_arg",
+        "hex_arg",
+        "bool_arg",
+        "storage_path",
+        "passcode",
+        "dut-node-id",
+    ]
+
+    dut_config = config.dut_config
+    test_parameters = config.test_parameters
+
+    pairing_mode = (
+        "on-network"
+        if dut_config.pairing_mode == "onnetwork"
+        else dut_config.pairing_mode
+    )
+
+    arguments = []
+    # Retrieve arguments from dut_config
+    arguments.append(f"--discriminator {dut_config.discriminator}")
+    arguments.append(f"--passcode {dut_config.setup_code}")
+    if not omit_commissioning_method:
+        arguments.append(f"--commissioning-method {pairing_mode}")
+
+    # Retrieve arguments from test_parameters
+
+    if test_parameters:
+        for name, value in test_parameters.items():
+            if name in valid_args:
+                if str(value) != "":
+                    arguments.append(f"--{name.replace('_','-')} {str(value)}")
+                else:
+                    arguments.append(f"--{name.replace('_','-')} " "")
+            else:
+                logger.warning(f"Argument {name} is not valid")
+
+    return arguments
+
+
+def handle_logs(log_generator: Generator, logger: loguru.Logger) -> None:
+    for chunk in log_generator:
+        decoded_log = chunk.decode().strip()
+        log_lines = decoded_log.splitlines()
+        for line in log_lines:
+            logger.log(PYTHON_TEST_LEVEL, line)

--- a/test_collections/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/sdk_tests/support/python_testing/models/utils.py
@@ -52,7 +52,7 @@ def generate_command_arguments(
         "bool_arg",
         "storage_path",
         "passcode",
-        "dut-node-id",
+        "dut_node_id",
     ]
 
     dut_config = config.dut_config
@@ -72,7 +72,6 @@ def generate_command_arguments(
         arguments.append(f"--commissioning-method {pairing_mode}")
 
     # Retrieve arguments from test_parameters
-
     if test_parameters:
         for name, value in test_parameters.items():
             if name in valid_args:


### PR DESCRIPTION
## What changed

- Added support to run multiple python tests in one test run execution.
- This was done by commissioning the DUT on test suite setup and omitting the `commissioning-method` argument when running the test cases.
- Added the `commission` command to `test_harness_client.py`.
- Shut down the server after the test execution completes.


## Testing

<img width="2160" alt="Screenshot 2023-12-01 at 15 11 12" src="https://github.com/rquidute/certification-tool-backend/assets/116589288/06fdb1c3-bb56-4cf4-b0bc-8871f434a753">
